### PR TITLE
Fixed warnings during byte-compile

### DIFF
--- a/wget.el
+++ b/wget.el
@@ -898,7 +898,7 @@ Keybindings:
 	(insert "  --- Wget Process ---")
 	(if proc-alist
 	    (progn
-	      (mapcar 'wget-progress-update proc-alist)
+	      (mapc 'wget-progress-update proc-alist)
 	      (when (and
 		     (not (one-window-p))
 		     (> height (+ 2 (length proc-alist))))


### PR DESCRIPTION
Hello,

During the byte-compile of emacs-w3m, Emacs printed a lot of warnings like:

`  wget.el:441:16:Warning: Use ‘with-current-buffer’ rather than save-excursion+set-buffer`

I did what the warning suggested.

Also, there was this warning:

`  wget.el:905:16:Warning: ‘mapcar’ called for effect; use ‘mapc’ or ‘dolist’ instead`

I fixed that too by using mapc instead of mapcar.

I expect these changes should make no difference to the functioning of your code, but simply make the warnings go away.  I did a simple test using (wget) and it worked fine.